### PR TITLE
Merchant invoice index

### DIFF
--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -2,4 +2,8 @@ class MerchantInvoicesController < ApplicationController
     def index
         @merchant = Merchant.find(params[:id])
     end
+
+    def show
+        @invoice = Invoice.find(params[:invoice_id])
+    end
 end

--- a/app/controllers/merchant_invoices_controller.rb
+++ b/app/controllers/merchant_invoices_controller.rb
@@ -1,0 +1,5 @@
+class MerchantInvoicesController < ApplicationController
+    def index
+        @merchant = Merchant.find(params[:id])
+    end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,4 +2,5 @@ class Merchant < ApplicationRecord
   validates_presence_of :name
 
   has_many :items, dependent: :destroy
+  has_many :invoices, through: :items
 end

--- a/app/views/merchant_invoices/index.html.erb
+++ b/app/views/merchant_invoices/index.html.erb
@@ -4,7 +4,7 @@
     <h3> Invoices </h3>
     <% @merchant.invoices.distinct.each do |invoice| %>
         <div id="invoice-<%= invoice.id %>" >
-            <p> <%= invoice.id %> </p>
+           <%= link_to "Invoice ##{invoice.id}", "/merchants/#{@merchant.id}/invoices/#{invoice.id}" %>
         </div>
     <% end %>
 </div>

--- a/app/views/merchant_invoices/index.html.erb
+++ b/app/views/merchant_invoices/index.html.erb
@@ -1,0 +1,10 @@
+<h3> <%= @merchant.name %> </h3>
+
+<div>
+    <h3> Invoices </h3>
+    <% @merchant.invoices.distinct.each do |invoice| %>
+        <div id="invoice-<%= invoice.id %>" >
+            <p> <%= invoice.id %> </p>
+        </div>
+    <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get '/merchants/:id/invoices', to: 'merchant_invoices#index'
+  get '/merchants/:merchant_id/invoices/:invoice_id', to: 'merchant_invoices#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  get '/merchants/:id/invoices', to: 'merchant_invoices#index'
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Merchand invoice Index page' do
+RSpec.describe 'Merchant invoice Index page' do
     it 'shows a list of all invoices associated with a merchant' do
         merchant = Merchant.create!(name: 'amazon')
         merchant_2 = Merchant.create!(name: 'amazon')
@@ -19,16 +19,18 @@ RSpec.describe 'Merchand invoice Index page' do
 
         visit "/merchants/#{merchant.id}/invoices"
 
-        within "invoice-#{invoice_1.id}" do
+        within "#invoice-#{invoice_1.id}" do
             expect(page).to have_content(invoice_1.id)
             expect(page).to_not have_content(invoice_2.id)
         end
 
-        within "invoice-#{invoice_2.id}" do
+        within "#invoice-#{invoice_2.id}" do
             expect(page).to have_content(invoice_2.id)
             expect(page).to_not have_content(invoice_1.id)
         end
 
         expect(page).to_not have_content(invoice_3.id)
     end
+
+    
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -32,5 +32,27 @@ RSpec.describe 'Merchant invoice Index page' do
         expect(page).to_not have_content(invoice_3.id)
     end
 
-    
+    it 'invoice ids are links to the invoice show page' do
+        merchant = Merchant.create!(name: 'amazon')
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+        invoice_2 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 2, unit_price: 12345, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 2, unit_price: 12345, status: 'shipped', item: item_1, invoice: invoice_2)
+
+        visit "/merchants/#{merchant.id}/invoices"
+
+        within "#invoice-#{invoice_1.id}" do
+            expect(page).to have_link(invoice_1.id)
+        end
+
+        within "#invoice-#{invoice_2.id}" do
+            expect(page).to have_link(invoice_2.id)
+            click_on(invoice_2.id)
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant.id}/invoices/#{invoice_2.id}")
+    end
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchand invoice Index page' do
+    it 'shows a list of all invoices associated with a merchant' do
+        merchant = Merchant.create!(name: 'amazon')
+        merchant_2 = Merchant.create!(name: 'amazon')
+        customer = Customer.create!(first_name: 'Billy', last_name: 'Bob')
+        item_1 = Item.create!(name: 'pet rock', description: 'a rock you pet', unit_price: 10000, merchant_id: merchant.id)
+        item_2 = Item.create!(name: 'ferbie', description: 'monster toy', unit_price: 66600, merchant_id: merchant.id)
+        item_3 = Item.create!(name: 'bay blade', description: 'let it rip!', unit_price: 23400, merchant_id: merchant_2.id)
+        invoice_1 = Invoice.create!(status: 'completed', customer_id: customer.id)
+        invoice_2 = Invoice.create!(status: 'completed', customer_id: customer.id)
+        invoice_3 = Invoice.create!(status: 'completed', customer_id: customer.id)
+
+        InvoiceItem.create!(quantity: 2, unit_price: 12345, status: 'shipped', item: item_1, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 2, unit_price: 12345, status: 'shipped', item: item_2, invoice: invoice_1)
+        InvoiceItem.create!(quantity: 2, unit_price: 12345, status: 'shipped', item: item_1, invoice: invoice_2)
+        InvoiceItem.create!(quantity: 2, unit_price: 12345, status: 'shipped', item: item_3, invoice: invoice_3)
+
+        visit "/merchants/#{merchant.id}/invoices"
+
+        within "invoice-#{invoice_1.id}" do
+            expect(page).to have_content(invoice_1.id)
+            expect(page).to_not have_content(invoice_2.id)
+        end
+
+        within "invoice-#{invoice_2.id}" do
+            expect(page).to have_content(invoice_2.id)
+            expect(page).to_not have_content(invoice_1.id)
+        end
+
+        expect(page).to_not have_content(invoice_3.id)
+    end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Merchant, type: :model do
 
   describe 'relationships' do
     it { should have_many :items }
+    it { should have_many(:invoices)}
+    it { should have_many(:invoices).through(:items)}
   end
 
   before :each do


### PR DESCRIPTION
Merchant Invoices Index

As a merchant,
When I visit my merchant's invoices index (/merchants/merchant_id/invoices)
Then I see all of the invoices that include at least one of my merchant's items
And for each invoice I see its id
And each id links to the merchant invoice show page