### PR TITLE
Merchant Items - User Stories 6, 7, 8

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -1,0 +1,5 @@
+class MerchantItemsController < ApplicationController
+  def index
+    @merchant = Merchant.find(params[:merchant_id])
+  end
+end

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -2,4 +2,8 @@ class MerchantItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
   end
+
+  def show
+    @item = Item.find(params[:item_id])
+  end
 end

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -6,4 +6,23 @@ class MerchantItemsController < ApplicationController
   def show
     @item = Item.find(params[:item_id])
   end
+
+  def edit
+    @item = Item.find(params[:item_id])
+  end
+
+  # Will need to update to handle edge case of improper unit_price entry
+  # at a later date
+  # e.g. Typing in as float (3.50) instead of integer (350)
+  def update
+    item = Item.find(params[:item_id])
+    item.update(item_params)
+    flash[:notice] = "Item successfully updated!"
+    redirect_to "/merchants/#{item.merchant_id}/items/#{item.id}"
+  end
+
+  private
+  def item_params
+    params.permit(:name, :description, :unit_price)
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,6 @@ class Item < ApplicationRecord
     belongs_to :merchant
     has_many :invoice_items
     has_many :invoices, through: :invoice_items
+
+    enum status: [ :disabled, :enabled ]
 end

--- a/app/views/merchant_items/edit.html.erb
+++ b/app/views/merchant_items/edit.html.erb
@@ -1,0 +1,28 @@
+<h1>Edit Item</h1>
+
+<div id="update-form">
+  <%= form_with url: "/merchants/#{@item.merchant_id}/items/#{@item.id}", method: :patch, local: true do |form| %>
+    <div id="name-field">
+      <%= form.label :name, "Item Name: " %>
+      <%= form.text_field :name, value: @item.name %>
+    </div>
+
+    <br>
+
+    <div id="description-field">
+      <%= form.label :description, "Item Description: " %>
+      <%= form.text_area :description, value: @item.description %>
+    </div>
+
+    <br>
+
+    <div id="unit_price-field">
+      <%= form.label :unit_price, "Item Price: " %>
+      <%= form.number_field :unit_price, step: :any, value: @item.unit_price %>
+    </div>
+
+    <br>
+    
+    <%= form.submit 'Update Item' %>
+  <% end %>
+</div>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -1,9 +1,9 @@
-<h1>@merchant.name</h1>
+<h1><%= @merchant.name %></h1>
 
 <div id="items-section">
   <ul>
   <% @merchant.items.each do |item| %>
-    <li id="item-<%= item.id %>">item.name</li>
+    <li id="item-<%= item.id %>"><%= item.name %></li>
   <% end %>
   </ul>
 </div>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -3,7 +3,9 @@
 <div id="items-section">
   <ul>
   <% @merchant.items.each do |item| %>
-    <li id="item-<%= item.id %>"><%= item.name %></li>
+    <li id="item-<%= item.id %>">
+      <%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %>
+    </li>
   <% end %>
   </ul>
 </div>

--- a/app/views/merchant_items/show.html.erb
+++ b/app/views/merchant_items/show.html.erb
@@ -1,0 +1,9 @@
+<h1><%= @item.name %></h1>
+
+<div id="items-info">
+  <ul>
+    <li id="item-name"><%= @item.name %></li>
+    <li id="item-description"><%= @item.description %></li>
+    <li id="item-unit_price"><%= @item.unit_price %></li>
+  </ul>
+</div>

--- a/app/views/merchant_items/show.html.erb
+++ b/app/views/merchant_items/show.html.erb
@@ -1,5 +1,9 @@
 <h1><%= @item.name %></h1>
 
+<% if flash[:notice] %>
+  <div class="notice" style="color:green; font-size:150%;"><%= flash[:notice] %></div>
+<% end %>
+
 <div id="items-info">
   <ul>
     <li id="item-name"><%= @item.name %></li>
@@ -7,3 +11,5 @@
     <li id="item-unit_price"><%= @item.unit_price %></li>
   </ul>
 </div>
+
+<%= link_to "Update Information", "/merchants/#{@item.merchant_id}/items/#{@item.id}/edit" %>

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,0 +1,9 @@
+<h1>@merchant.name</h1>
+
+<div id="items-section">
+  <ul>
+  <% @merchant.items.each do |item| %>
+    <li id="item-<%= item.id %>">item.name</li>
+  <% end %>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get '/merchants/:merchant_id/items', to: 'merchant_items#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/merchants/:merchant_id/items', to: 'merchant_items#index'
+  get '/merchants/:merchant_id/items/:item_id', to: 'merchant_items#show'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/merchants/:merchant_id/items', to: 'merchant_items#index'
   get '/merchants/:merchant_id/items/:item_id', to: 'merchant_items#show'
+  get '/merchants/:merchant_id/items/:item_id/edit', to: 'merchant_items#edit'
+  patch  '/merchants/:merchant_id/items/:item_id', to: 'merchant_items#update'
+  
+  # get '/items/:item_id/edit', to: 'items#edit'
+  # patch '/items/:item_id', to: 'items#update'
 end

--- a/db/migrate/7_add_status_to_items.rb
+++ b/db/migrate/7_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 6) do
+ActiveRecord::Schema.define(version: 7) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 6) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Merchant Items Show Page' do
+RSpec.describe 'Merchant Items Edit Page' do
   before :each do
     @walmart = Merchant.create!(name: "Wal-Mart")
 
@@ -29,28 +29,6 @@ RSpec.describe 'Merchant Items Show Page' do
                             merchant_id: @target.id)
   end
 
-  # User Story 7
-  # Merchant Items Show Page
-
-  # As a merchant,
-  # When I click on the name of an item from the merchant items index page,
-  # Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
-  # And I see all of the item's attributes including:
-
-  # Name
-  # Description
-  # Current Selling Price
-  it 'has all of the attributes for a specific merchant item' do
-    visit "/merchants/#{@walmart.id}/items/#{@pencil.id}"
-
-    expect(page).to have_content(@pencil.name)
-    expect(page).to have_content(@pencil.description)
-    expect(page).to have_content(@pencil.unit_price)
-    expect(page).to_not have_content(@marker.name)
-    expect(page).to_not have_content(@eraser.name)
-    expect(page).to_not have_content(@highlighter.name)
-  end
-
   # User Story 8
   # Merchant Item Update
 
@@ -63,13 +41,46 @@ RSpec.describe 'Merchant Items Show Page' do
   # When I update the information in the form and I click ‘submit’
   # Then I am redirected back to the item show page where I see the updated information
   # And I see a flash message stating that the information has been successfully updated.
-  it 'has a link to update information for an item' do
-    visit "/merchants/#{@walmart.id}/items/#{@pencil.id}"
+  it 'has a form pre-filled with the existing attribute information for an item' do
+    visit "/merchants/#{@walmart.id}/items/#{@pencil.id}/edit"
 
-    expect(page).to have_link("Update Information", href: "/merchants/#{@walmart.id}/items/#{@pencil.id}/edit")
+    within '#name-field' do
+      expect(page).to have_field(:name, with: @pencil.name)
+    end
+    
+    within '#description-field' do
+      expect(page).to have_field(:description, with: @pencil.description)
+    end
 
-    click_link("Update Information")
+    within '#unit_price-field' do
+      expect(page).to have_field(:unit_price, with: @pencil.unit_price)
+    end
+  end
 
-    expect(current_path).to eq("/merchants/#{@walmart.id}/items/#{@pencil.id}/edit")
+  it 'can update the information for an item' do
+    visit "/merchants/#{@walmart.id}/items/#{@pencil.id}/edit"
+
+    within '#name-field' do
+      fill_in :name, with: "Mechanical Pencil"
+    end
+    
+    within '#description-field' do
+      fill_in :description, with: "You can refill it with lead!"
+    end
+
+    within '#unit_price-field' do
+      fill_in :unit_price, with: 299
+    end
+
+    click_button 'Update Item'
+
+    expect(current_path).to eq("/merchants/#{@walmart.id}/items/#{@pencil.id}")
+
+    expect(page).to have_content("Item successfully updated!")
+    expect(page).to have_content("Mechanical Pencil")
+    expect(page).to have_content("You can refill it with lead!")
+    expect(page).to have_content(299)
+    expect(page).to_not have_content("Sharpen it and write with it.")
+    expect(page).to_not have_content(199)
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -39,9 +39,50 @@ RSpec.describe 'Merchant Items Index' do
   it 'has a list of all of the items for a merchant' do
     visit "/merchants/#{@walmart.id}/items"
 
-    expect(page).to have_content(@pencil.name)
-    expect(page).to have_content(@marker.name)
-    expect(page).to have_content(@eraser.name)
-    expect(page).to_not have_content(@highlighter.name)
+    within '#items-section' do
+      expect(page).to have_content(@pencil.name)
+      expect(page).to have_content(@marker.name)
+      expect(page).to have_content(@eraser.name)
+      expect(page).to_not have_content(@highlighter.name)
+    end
+  end
+
+  # User Story 2
+  # Merchant Items Show Page
+
+  # As a merchant,
+  # When I click on the name of an item from the merchant items index page,
+  # Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
+  # And I see all of the item's attributes including:
+
+  # Name
+  # Description
+  # Current Selling Price
+  it 'has links to show pages of merchant items' do
+    visit "/merchants/#{@walmart.id}/items"
+
+    within '#items-section' do
+      expect(page).to_not have_content(@highlighter.name)
+
+      within "#item-#{@pencil.id}" do
+        expect(page).to have_link("#{@pencil.name}", href: "/merchants/#{@walmart.id}/items/#{@pencil.id}")
+      end
+
+      within "#item-#{@marker.id}" do
+        expect(page).to have_link("#{@marker.name}", href: "/merchants/#{@walmart.id}/items/#{@marker.id}")
+      end
+
+      within "#item-#{@eraser.id}" do
+        expect(page).to have_link("#{@eraser.name}", href: "/merchants/#{@walmart.id}/items/#{@eraser.id}")
+      end
+    end
+  end
+
+  it 'has links to take you to a merchant item show page' do
+    visit "/merchants/#{@walmart.id}/items"
+
+    click_link "#{@pencil.name}"
+
+    expect(current_path).to eq("/merchants/#{@walmart.id}/items/#{@pencil.id}")
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -26,10 +26,16 @@ RSpec.describe 'Merchant Items Index' do
     @highlighter = Item.create!( name: "Highlighter",
                             description: "Highlight things and make them yellow!",
                             unit_price: 305,
-                            merchant_id: @walmart.id)
-
+                            merchant_id: @target.id)
   end
 
+  # User Story 1
+  # Merchant Items Index Page
+
+  # As a merchant,
+  # When I visit my merchant items index page ("merchants/merchant_id/items")
+  # I see a list of the names of all of my items
+  # And I do not see items for any other merchant
   it 'has a list of all of the items for a merchant' do
     visit "/merchants/#{@walmart.id}/items"
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Merchant Items Index' do
                             merchant_id: @target.id)
   end
 
-  # User Story 1
+  # User Story 6
   # Merchant Items Index Page
 
   # As a merchant,
@@ -47,7 +47,7 @@ RSpec.describe 'Merchant Items Index' do
     end
   end
 
-  # User Story 2
+  # User Story 7
   # Merchant Items Show Page
 
   # As a merchant,

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -39,8 +39,6 @@ RSpec.describe 'Merchant Items Index' do
   it 'has a list of all of the items for a merchant' do
     visit "/merchants/#{@walmart.id}/items"
 
-    save_and_open_page
-
     expect(page).to have_content(@pencil.name)
     expect(page).to have_content(@marker.name)
     expect(page).to have_content(@eraser.name)

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Items Index' do
+  before :each do
+    @walmart = Merchant.create!(name: "Wal-Mart")
+
+    @target = Merchant.create!(name: "Target")
+
+    @costco = Merchant.create!(name: "Costco")
+
+    @pencil = Item.create!( name: "Pencil",
+                            description: "Sharpen it and write with it.",
+                            unit_price: 199,
+                            merchant_id: @walmart.id)
+
+    @marker = Item.create!( name: "Marker",
+                            description: "Washable!",
+                            unit_price: 159,
+                            merchant_id: @walmart.id)
+
+    @eraser = Item.create!( name: "Eraser",
+                            description: "Use it to fix mistakes.",
+                            unit_price: 205,
+                            merchant_id: @walmart.id)
+
+    @highlighter = Item.create!( name: "Highlighter",
+                            description: "Highlight things and make them yellow!",
+                            unit_price: 305,
+                            merchant_id: @walmart.id)
+
+  end
+
+  it 'has a list of all of the items for a merchant' do
+    visit "/merchants/#{@walmart.id}/items"
+
+    save_and_open_page
+
+    expect(page).to have_content(@pencil.name)
+    expect(page).to have_content(@marker.name)
+    expect(page).to have_content(@eraser.name)
+    expect(page).to_not have_content(@highlighter.name)
+  end
+end

--- a/spec/features/merchants/items/show_spec.rb
+++ b/spec/features/merchants/items/show_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchant Items Show Page' do
+  before :each do
+    @walmart = Merchant.create!(name: "Wal-Mart")
+
+    @target = Merchant.create!(name: "Target")
+
+    @costco = Merchant.create!(name: "Costco")
+
+    @pencil = Item.create!( name: "Pencil",
+                            description: "Sharpen it and write with it.",
+                            unit_price: 199,
+                            merchant_id: @walmart.id)
+
+    @marker = Item.create!( name: "Marker",
+                            description: "Washable!",
+                            unit_price: 159,
+                            merchant_id: @walmart.id)
+
+    @eraser = Item.create!( name: "Eraser",
+                            description: "Use it to fix mistakes.",
+                            unit_price: 205,
+                            merchant_id: @walmart.id)
+
+    @highlighter = Item.create!( name: "Highlighter",
+                            description: "Highlight things and make them yellow!",
+                            unit_price: 305,
+                            merchant_id: @target.id)
+  end
+
+  # User Story 2
+  # Merchant Items Show Page
+
+  # As a merchant,
+  # When I click on the name of an item from the merchant items index page,
+  # Then I am taken to that merchant's item's show page (/merchants/merchant_id/items/item_id)
+  # And I see all of the item's attributes including:
+
+  # Name
+  # Description
+  # Current Selling Price
+  it 'has all of the attributes for a specific merchant item' do
+    visit "/merchants/#{@walmart.id}/items/#{@pencil.id}"
+
+    expect(page).to have_content(@pencil.name)
+    expect(page).to have_content(@pencil.description)
+    expect(page).to have_content(@pencil.unit_price)
+    expect(page).to_not have_content(@marker.name)
+    expect(page).to_not have_content(@eraser.name)
+    expect(page).to_not have_content(@highlighter.name)
+  end
+end


### PR DESCRIPTION
Adds functionality to pass User Stories 6, 7, 8, and begin on User Story 9 (Item has a disabled/enabled status). May need to come back to the Item Update section at a later point to address edge case of improper user input (float instead of integer). 