### PR TITLE
Us4 merchant dashboard items ready to ship & US 5 merchant dashboard invoices sorted

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -17,12 +17,16 @@ class Merchant < ApplicationRecord
     
     # binding.pry 
     
-    test = customers
+    customers
     .joins(:transactions)
     .where(transactions: { result: 'success' })
     .group(:id)
     .select('customers.*, count(*) as success_count')
     .order('success_count desc')
     .limit(5)
+  end
+
+  def unshipped_items
+    items.joins(:invoice_items).where(invoice_items: { status: 'packaged' }).select('items.*, invoice_items.invoice_id as invoice_id')
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -27,6 +27,6 @@ class Merchant < ApplicationRecord
   end
 
   def unshipped_items
-    items.joins(:invoice_items).where(invoice_items: { status: 'packaged' }).select('items.*, invoice_items.invoice_id as invoice_id')
+    items.joins(:invoice_items).where(invoice_items: { status: 'packaged' }).select('items.*, invoice_items.invoice_id as invoice_id').order(:invoice_id)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -15,8 +15,6 @@ class Merchant < ApplicationRecord
     # .select('customers.*, count(transactions.result) as transaction_total')
     # .group(:id)
     
-    # binding.pry 
-    
     customers
     .joins(:transactions)
     .where(transactions: { result: 'success' })
@@ -27,6 +25,7 @@ class Merchant < ApplicationRecord
   end
 
   def unshipped_items
-    items.joins(:invoice_items).where(invoice_items: { status: 'packaged' }).select('items.*, invoice_items.invoice_id as invoice_id').order(:invoice_id)
+    # items.joins(:invoice_items).where(invoice_items: { status: 'packaged' }).select('items.*, invoice_items.invoice_id as invoice_id').order(:invoice_id)
+    invoice_items.joins(:invoice).where(status: 1).order("invoices.created_at")
   end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -9,9 +9,9 @@
 </p>
 
 <b>Items Ready to Ship</b>
-<% @merchant.unshipped_items.each_with_index do |item, index| %>
+<% @merchant.unshipped_items.each_with_index do |invoice_item, index| %>
     <div id = "item-<%= index %>">
-        <%= item.name %> - <%= link_to "Invoice ##{item.invoice_id}", merchant_invoice_path(@merchant.id, item.invoice_id) %>
+        <%= invoice_item.item.name %> - <%= link_to "Invoice ##{invoice_item.invoice_id}", merchant_invoice_path(@merchant.id, invoice_item.invoice_id) %> - <%= invoice_item.invoice.created_at.strftime("%A, %B %e, %Y") %>
     </div>
 <% end %>
 <br>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -11,7 +11,7 @@
 <b>Items Ready to Ship</b>
 <% @merchant.unshipped_items.each_with_index do |item, index| %>
     <div id = "item-<%= index %>">
-        <%= item.name %> - Invoice #<%= item.invoice_id %>
+        <%= item.name %> - <%= link_to "Invoice ##{item.invoice_id}", merchant_invoice_path(@merchant.id, item.invoice_id) %>
     </div>
 <% end %>
 <br>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -8,6 +8,14 @@
 <%= link_to 'My Invoices', merchant_invoices_path(@merchant) %>
 </p>
 
+<b>Items Ready to Ship</b>
+<% @merchant.unshipped_items.each_with_index do |item, index| %>
+    <div id = "item-<%= index %>">
+        <%= item.name %> - Invoice #<%= item.invoice_id %>
+    </div>
+<% end %>
+<br>
+
 <b>Favorite Customers</b>
 <div id='top-5' >
 <ol>

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -318,7 +318,6 @@ RSpec.describe 'Merchant Dashboard' do
         transaction_7a_6 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
         transaction_7a_7 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
 
-
         visit "merchants/#{merchant_1.id}/dashboard" 
         # save_and_open_page
 
@@ -377,7 +376,7 @@ RSpec.describe 'Merchant Dashboard' do
         expect(page).to have_content('Items Ready to Ship')
 
         within("#item-0") do 
-            expect(page).to have_content('Book of Rails')
+            expect(page).to have_content('Dog Water Bottle')
         end
 
         within("#item-1") do 
@@ -385,15 +384,15 @@ RSpec.describe 'Merchant Dashboard' do
         end
 
         within("#item-2") do 
-            expect(page).to have_content('Dog Water Bottle')
+            expect(page).to have_content('Book of Rails')
         end
 
         within("#item-3") do 
-            expect(page).to have_content('Dog Scratcher')
+            expect(page).to have_content('Dog Water Bottle')
         end
 
         within("#item-4") do 
-            expect(page).to have_content('Dog Water Bottle')
+            expect(page).to have_content('Dog Scratcher')
         end
 
         expect(page).to_not have_content('Turtle Stickers')
@@ -499,4 +498,63 @@ RSpec.describe 'Merchant Dashboard' do
 
         expect(current_path).to eq("/merchants/#{merchant_1.id}/invoices/#{invoice_1b.id}")
     end 
+
+    # Merchant Dashboard Invoices sorted by least recent
+    # As a merchant
+    # When I visit my merchant dashboard
+    # In the section for "Items Ready to Ship",
+    # Next to each Item name I see the date that the invoice was created
+    # And I see the date formatted like "Monday, July 18, 2019"
+    # And I see that the list is ordered from oldest to newest
+    it 'displays the date the invoice was created' do 
+        merchant_1 = Merchant.create!(name: 'Mike Dao')
+
+        item_1 = merchant_1.items.create!(name: 'Book of Rails', description: 'book on rails', unit_price: 2000)
+        item_2 = merchant_1.items.create!(name: 'Dog Scratcher', description: 'scratches dogs', unit_price: 800)
+        item_3 = merchant_1.items.create!(name: 'Dog Water Bottle', description: 'dogs can drink from it', unit_price: 1600)
+        item_4 = merchant_1.items.create!(name: 'Turtle Stickers', description: 'stickers of turtles', unit_price: 400)
+
+        # customer_1 
+        customer_1 = Customer.create!(first_name: 'Anna Marie', last_name: 'Sterling')
+
+        invoice_1a = customer_1.invoices.create!(status: 1)
+
+        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
+
+        invoice_1b = customer_1.invoices.create!(status: 0)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
+
+        visit "merchants/#{merchant_1.id}/dashboard" 
+        # save_and_open_page 
+
+        invoice_1a_date = invoice_1a.created_at.strftime("%A, %B %e, %Y")
+        invoice_1b_date = invoice_1b.created_at.strftime("%A, %B %e, %Y")
+
+        within("#item-0") do 
+            expect(page).to have_content(invoice_1a_date)
+        end
+
+        within("#item-1") do 
+            expect(page).to have_content(invoice_1a_date)
+
+        end
+
+        within("#item-2") do 
+            expect(page).to have_content(invoice_1a_date)
+
+        end
+
+        within("#item-3") do 
+            expect(page).to have_content(invoice_1b_date)
+
+        end
+
+        within("#item-4") do 
+            expect(page).to have_content(invoice_1b_date)
+        end
+    end
 end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -349,7 +349,103 @@ RSpec.describe 'Merchant Dashboard' do
     # Then I see a section for "Items Ready to Ship"
     # In that section I see a list of the names of all of my items that
     # have been ordered and have not yet been shipped,
-    # And next to each Item I see the id of the invoice that ordered my item
-    # And each invoice id is a link to my merchant's invoice show page
+    it 'has a section with a list of items that have been ordered but not yet been shipped' do 
+        merchant_1 = Merchant.create!(name: 'Mike Dao')
 
+        item_1 = merchant_1.items.create!(name: 'Book of Rails', description: 'book on rails', unit_price: 2000)
+        item_2 = merchant_1.items.create!(name: 'Dog Scratcher', description: 'scratches dogs', unit_price: 800)
+        item_3 = merchant_1.items.create!(name: 'Dog Water Bottle', description: 'dogs can drink from it', unit_price: 1600)
+        item_4 = merchant_1.items.create!(name: 'Turtle Stickers', description: 'stickers of turtles', unit_price: 400)
+
+        # customer_1 
+        customer_1 = Customer.create!(first_name: 'Anna Marie', last_name: 'Sterling')
+
+        invoice_1a = customer_1.invoices.create!(status: 1)
+
+        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
+
+        invoice_1b = customer_1.invoices.create!(status: 0)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
+
+        visit "merchants/#{merchant_1.id}/dashboard" 
+        # save_and_open_page 
+
+        expect(page).to have_content('Items Ready to Ship')
+
+        within("#item-0") do 
+            expect(page).to have_content('Book of Rails')
+        end
+
+        within("#item-1") do 
+            expect(page).to have_content('Dog Scratcher')
+        end
+
+        within("#item-2") do 
+            expect(page).to have_content('Dog Scratcher')
+        end
+
+        within("#item-3") do 
+            expect(page).to have_content('Dog Water Bottle')
+        end
+
+        within("#item-4") do 
+            expect(page).to have_content('Dog Water Bottle')
+        end
+
+        expect(page).to_not have_content('Turtle Stickers')
+    end 
+
+    # And next to each Item I see the id of the invoice that ordered my item
+    it 'lists the invoice id next to the Item waiting to be shipped' do 
+        merchant_1 = Merchant.create!(name: 'Mike Dao')
+
+        item_1 = merchant_1.items.create!(name: 'Book of Rails', description: 'book on rails', unit_price: 2000)
+        item_2 = merchant_1.items.create!(name: 'Dog Scratcher', description: 'scratches dogs', unit_price: 800)
+        item_3 = merchant_1.items.create!(name: 'Dog Water Bottle', description: 'dogs can drink from it', unit_price: 1600)
+        item_4 = merchant_1.items.create!(name: 'Turtle Stickers', description: 'stickers of turtles', unit_price: 400)
+
+        # customer_1 
+        customer_1 = Customer.create!(first_name: 'Anna Marie', last_name: 'Sterling')
+
+        invoice_1a = customer_1.invoices.create!(status: 1)
+
+        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
+
+        invoice_1b = customer_1.invoices.create!(status: 0)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
+
+        visit "merchants/#{merchant_1.id}/dashboard" 
+        save_and_open_page 
+
+        expect(page).to have_content('Items Ready to Ship')
+
+        within("#item-0") do 
+            expect(page).to have_content(invoice_1a.id)
+        end
+
+        within("#item-1") do 
+            expect(page).to have_content(invoice_1a.id)
+        end
+
+        within("#item-2") do 
+            expect(page).to have_content(invoice_1b.id)
+        end
+
+        within("#item-3") do 
+            expect(page).to have_content(invoice_1a.id)
+        end
+
+        within("#item-4") do 
+            expect(page).to have_content(invoice_1b.id)
+        end
+    end 
+    # And each invoice id is a link to my merchant's invoice show page
 end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -385,11 +385,11 @@ RSpec.describe 'Merchant Dashboard' do
         end
 
         within("#item-2") do 
-            expect(page).to have_content('Dog Scratcher')
+            expect(page).to have_content('Dog Water Bottle')
         end
 
         within("#item-3") do 
-            expect(page).to have_content('Dog Water Bottle')
+            expect(page).to have_content('Dog Scratcher')
         end
 
         within("#item-4") do 
@@ -423,7 +423,7 @@ RSpec.describe 'Merchant Dashboard' do
         InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
 
         visit "merchants/#{merchant_1.id}/dashboard" 
-        save_and_open_page 
+        # save_and_open_page 
 
         expect(page).to have_content('Items Ready to Ship')
 
@@ -436,16 +436,67 @@ RSpec.describe 'Merchant Dashboard' do
         end
 
         within("#item-2") do 
-            expect(page).to have_content(invoice_1b.id)
+            expect(page).to have_content(invoice_1a.id)
         end
 
         within("#item-3") do 
-            expect(page).to have_content(invoice_1a.id)
+            expect(page).to have_content(invoice_1b.id)
         end
 
         within("#item-4") do 
             expect(page).to have_content(invoice_1b.id)
         end
     end 
+
     # And each invoice id is a link to my merchant's invoice show page
+    it 'has a section with a list of items that have been ordered but not yet been shipped' do 
+        merchant_1 = Merchant.create!(name: 'Mike Dao')
+
+        item_1 = merchant_1.items.create!(name: 'Book of Rails', description: 'book on rails', unit_price: 2000)
+        item_2 = merchant_1.items.create!(name: 'Dog Scratcher', description: 'scratches dogs', unit_price: 800)
+        item_3 = merchant_1.items.create!(name: 'Dog Water Bottle', description: 'dogs can drink from it', unit_price: 1600)
+        item_4 = merchant_1.items.create!(name: 'Turtle Stickers', description: 'stickers of turtles', unit_price: 400)
+
+        # customer_1 
+        customer_1 = Customer.create!(first_name: 'Anna Marie', last_name: 'Sterling')
+
+        invoice_1a = customer_1.invoices.create!(status: 1)
+
+        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
+
+        invoice_1b = customer_1.invoices.create!(status: 0)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
+
+        visit "merchants/#{merchant_1.id}/dashboard" 
+        # save_and_open_page 
+
+        within("#item-0") do 
+            expect(page).to have_link("Invoice ##{invoice_1a.id}")
+        end
+
+        within("#item-1") do 
+            expect(page).to have_link("Invoice ##{invoice_1a.id}")
+        end
+
+        within("#item-2") do 
+            expect(page).to have_link("Invoice ##{invoice_1a.id}")
+        end
+
+        within("#item-3") do 
+            expect(page).to have_link("Invoice ##{invoice_1b.id}")
+        end
+
+        within("#item-4") do 
+            expect(page).to have_link("Invoice ##{invoice_1b.id}")
+
+            click_link "Invoice ##{invoice_1b.id}"
+            # save_and_open_page
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/invoices/#{invoice_1b.id}")
+    end 
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -145,9 +145,8 @@ RSpec.describe Merchant, type: :model do
       end
     end
 
-    describe '#top_5' do 
-      it 'returns the top 5 customers who have conducted the largest number of successful transactions with my merchant' do 
-        Transaction.destroy_all
+    describe '#unshipped_items' do 
+      it 'returns a list of items that have been ordered and not yet hsipped' do 
         merchant_1 = Merchant.create!(name: 'Mike Dao')
 
         item_1 = merchant_1.items.create!(name: 'Book of Rails', description: 'book on rails', unit_price: 2000)
@@ -160,113 +159,18 @@ RSpec.describe Merchant, type: :model do
 
         invoice_1a = customer_1.invoices.create!(status: 1)
 
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_1a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'shipped', item: item_2, invoice: invoice_1a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'shipped', item: item_3, invoice: invoice_1a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
 
-        # transaction_1a_1 = Transaction.create!(credit_card_number: '1234', result: 'success', invoice_id: invoice_1a.id)
 
-        transaction_1a_1 = invoice_1a.transactions.create!(credit_card_number: '1234', result: 'success')
-        transaction_1a_2 = invoice_1a.transactions.create!(credit_card_number: '1234', result: 'success')
-        transaction_1a_3 = invoice_1a.transactions.create!(credit_card_number: '1234', result: 'success')
-        transaction_1a_4 = invoice_1a.transactions.create!(credit_card_number: '1234', result: 'success')
+        invoice_1b = customer_1.invoices.create!(status: 0)
+        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
+        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
 
-        invoice_1b = customer_1.invoices.create!(status: 1)
-
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_1b)
-        
-        transaction_1b_1 = invoice_1b.transactions.create!(credit_card_number: '1234', result: 'success')
-
-        # customer_2 
-
-        customer_2 = Customer.create!(first_name: 'Carlos', last_name: 'Stich')
-
-        invoice_2a = customer_2.invoices.create!(status: 1) 
-
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_2a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'shipped', item: item_2, invoice: invoice_2a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'shipped', item: item_3, invoice: invoice_2a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_2a)
-
-        transaction_2a_1 = invoice_2a.transactions.create!(credit_card_number: '2345', result: 'success')
-        transaction_2a_2 = invoice_2a.transactions.create!(credit_card_number: '2345', result: 'success')
-        transaction_2a_3 = invoice_2a.transactions.create!(credit_card_number: '2345', result: 'success')
-        transaction_2a_4 = invoice_2a.transactions.create!(credit_card_number: '2345', result: 'success')
-
-        # customer_3
-
-        customer_3 = Customer.create!(first_name: 'Bob', last_name: 'Builder')
-
-        invoice_3a = customer_3.invoices.create!(status: 2)
-
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_3a)
-
-        transaction_3a_1 = invoice_3a.transactions.create!(credit_card_number: '3456', result: 'failed')
-
-        # customer_4 
-
-        customer_4 = Customer.create!(first_name: 'Cindy', last_name: 'Crawford')
-
-        invoice_4a = customer_4.invoices.create!(status: 1)
-
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_4a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'shipped', item: item_2, invoice: invoice_4a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'shipped', item: item_3, invoice: invoice_4a)
-
-        transaction_4a_1 = invoice_4a.transactions.create!(credit_card_number: '5678', result: 'success')
-        transaction_4a_2 = invoice_4a.transactions.create!(credit_card_number: '5678', result: 'success')
-        transaction_4a_3 = invoice_4a.transactions.create!(credit_card_number: '5678', result: 'success')
-
-        # customer_5
-
-        customer_5 = Customer.create!(first_name: 'Gigi', last_name: 'Hadid')
-        invoice_5a = customer_5.invoices.create!(status: 1)
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_5a)
-        transaction_5a_1 = invoice_5a.transactions.create!(credit_card_number: '6789', result: 'success')
-
-        # customer_6
-
-        customer_6 = Customer.create!(first_name: 'Jessie', last_name: 'J')
-        invoice_6a = customer_6.invoices.create!(status: 1)
-
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_6a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'shipped', item: item_2, invoice: invoice_6a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'shipped', item: item_3, invoice: invoice_6a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_6a)
-        InvoiceItem.create!(quantity: 3, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_6a)
-
-        transaction_6a_1 = invoice_6a.transactions.create!(credit_card_number: '7890', result: 'success')
-        transaction_6a_2 = invoice_6a.transactions.create!(credit_card_number: '7890', result: 'success')
-        transaction_6a_3 = invoice_6a.transactions.create!(credit_card_number: '7890', result: 'success')
-        transaction_6a_4 = invoice_6a.transactions.create!(credit_card_number: '7890', result: 'success')
-        transaction_6a_5 = invoice_6a.transactions.create!(credit_card_number: '7890', result: 'success')
-        transaction_6a_6 = invoice_6a.transactions.create!(credit_card_number: '7890', result: 'success')
-
-        # customer_7
-
-        customer_7 = Customer.create!(first_name: 'Channing', last_name: 'Tatum')
-        invoice_7a = customer_7.invoices.create!(status: 1)
-
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_7a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'shipped', item: item_2, invoice: invoice_7a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'shipped', item: item_3, invoice: invoice_7a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_7a)
-        InvoiceItem.create!(quantity: 3, unit_price: item_1.unit_price, status: 'shipped', item: item_1, invoice: invoice_7a)
-        InvoiceItem.create!(quantity: 3, unit_price: item_2.unit_price, status: 'shipped', item: item_2, invoice: invoice_7a)
-
-        transaction_7a_1 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-        transaction_7a_2 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-        transaction_7a_3 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-        transaction_7a_4 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-        transaction_7a_5 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-        transaction_7a_6 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-        transaction_7a_7 = invoice_7a.transactions.create!(credit_card_number: '8901', result: 'success')
-
-        # binding.pry 
-
-        expect(merchant_1.top_5).to eq([customer_7, customer_6, customer_1, customer_2, customer_4])
-      end
+        expect(merchant_1.unshipped_items).to contain_exactly(item_1, item_2, item_3, item_2, item_3)
+      end 
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -146,7 +146,8 @@ RSpec.describe Merchant, type: :model do
     end
 
     describe '#unshipped_items' do 
-      it 'returns a list of items that have been ordered and not yet hsipped' do 
+      it 'returns a list of items that have been ordered and not yet shipped' do 
+        Item.destroy_all
         merchant_1 = Merchant.create!(name: 'Mike Dao')
 
         item_1 = merchant_1.items.create!(name: 'Book of Rails', description: 'book on rails', unit_price: 2000)
@@ -159,17 +160,17 @@ RSpec.describe Merchant, type: :model do
 
         invoice_1a = customer_1.invoices.create!(status: 1)
 
-        InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
+        ii1 = InvoiceItem.create!(quantity: 2, unit_price: item_1.unit_price, status: 'packaged', item: item_1, invoice: invoice_1a)
+        ii2 = InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1a)
+        ii3 = InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1a)
 
 
         invoice_1b = customer_1.invoices.create!(status: 0)
-        InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
-        InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
-        InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
+        ii4 = InvoiceItem.create!(quantity: 2, unit_price: item_2.unit_price, status: 'packaged', item: item_2, invoice: invoice_1b)
+        ii5 = InvoiceItem.create!(quantity: 2, unit_price: item_3.unit_price, status: 'packaged', item: item_3, invoice: invoice_1b)
+        ii6 = InvoiceItem.create!(quantity: 2, unit_price: item_4.unit_price, status: 'shipped', item: item_4, invoice: invoice_1b)
 
-        expect(merchant_1.unshipped_items).to contain_exactly(item_1, item_2, item_3, item_2, item_3)
+        expect(merchant_1.unshipped_items).to contain_exactly(ii1, ii2, ii3, ii4, ii5)
       end 
     end
   end


### PR DESCRIPTION
Merchant Dashboard Items Ready to Ship

As a merchant
When I visit my merchant dashboard
Then I see a section for "Items Ready to Ship"
In that section I see a list of the names of all of my items that
have been ordered and have not yet been shipped,
And next to each Item I see the id of the invoice that ordered my item
And each invoice id is a link to my merchant's invoice show page

As a merchant
When I visit my merchant dashboard
In the section for "Items Ready to Ship",
Next to each Item name I see the date that the invoice was created
And I see the date formatted like "Monday, July 18, 2019"
And I see that the list is ordered from oldest to newest