### PR TITLE
add faker gem and merchant names to admin merchants index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'orderly'
   gem 'launchy'
   gem 'database_cleaner', '~> 2.0', '>= 2.0.1'
+  gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/faker-ruby/faker.git
+  revision: efc6a90d845a25a34ddbcc9280ed951ecd346163
+  branch: master
+  specs:
+    faker (2.22.0)
+      i18n (>= 1.8.11, < 2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -231,6 +239,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   database_cleaner (~> 2.0, >= 2.0.1)
+  faker!
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,5 @@
+class Admin::MerchantsController < ApplicationController 
+    def index 
+        @merchants = Merchant.all 
+    end
+end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,0 +1,8 @@
+<h4>Enabled Merchants</h4>
+
+<% @merchants.each_with_index do |merchant, index| %>
+    <div id = "merchant-<%=index %>">
+        <%= merchant.name %>
+        <br>
+    </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
 
   root 'welcome#index'
 
+  namespace :admin do 
+    resources :merchants, only: [:index]
+  end
+
   resources :merchants, only: [:index]  do
     resources :items, only: [:index, :show, :new, :create, :edit, :update], :controller => 'merchant_items'
     resources :invoices, only: [:index, :show, :update], :controller => 'merchant_invoices'

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper' 
+require 'faker' 
+require 'pry'
+
+RSpec.describe 'Admin Merchants Index' do 
+    # Admin Merchants Index
+    # As an admin,
+    # When I visit the admin merchants index (/admin/merchants)
+    # Then I see the name of each merchant in the system
+    it 'shows the name of each merchant in the system' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit '/admin/merchants' 
+        # save_and_open_page
+
+        within('#merchant-0') do 
+            expect(page).to have_content(merchant_1.name)
+        end
+
+        within('#merchant-1') do 
+            expect(page).to have_content(merchant_2.name)
+        end
+
+        within('#merchant-2') do 
+            expect(page).to have_content(merchant_3.name)
+        end
+
+        within('#merchant-3') do 
+            expect(page).to have_content(merchant_4.name)
+        end
+    end
+end


### PR DESCRIPTION
Admin Merchants Index

As an admin,
When I visit the admin merchants index (/admin/merchants)
Then I see the name of each merchant in the system