### PR TITLE
Us25 admin merchant show

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -2,4 +2,8 @@ class Admin::MerchantsController < ApplicationController
     def index 
         @merchants = Merchant.all 
     end
+
+    def show
+        @merchant = Merchant.find(params[:id])
+    end
 end

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @merchants.each_with_index do |merchant, index| %>
     <div id = "merchant-<%=index %>">
-        <%= merchant.name %>
+        <%= link_to merchant.name, admin_merchant_path(merchant) %>
         <br>
     </div>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @merchant.name %></h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :admin do 
-    resources :merchants, only: [:index]
+    resources :merchants, only: [:index, :show]
   end
 
   resources :merchants, only: [:index]  do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin Merchants Index' do
         merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
         merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
 
-        visit '/admin/merchants' 
+        visit admin_merchants_path
         # save_and_open_page
 
         within('#merchant-0') do 
@@ -46,7 +46,7 @@ RSpec.describe 'Admin Merchants Index' do
         merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
         merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
 
-        visit '/admin/merchants' 
+        visit admin_merchants_path
 
         within('#merchant-0') do 
             expect(page).to have_link(merchant_1.name)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -33,4 +33,42 @@ RSpec.describe 'Admin Merchants Index' do
             expect(page).to have_content(merchant_4.name)
         end
     end
+
+    # Admin Merchant Show
+    # As an admin,
+    # When I click on the name of a merchant from the admin merchants index page,
+    # Then I am taken to that merchant's admin show page (/admin/merchants/merchant_id)
+    # And I see the name of that merchant
+    it 'has links to the merchants admin show page' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit '/admin/merchants' 
+
+        within('#merchant-0') do 
+            expect(page).to have_link(merchant_1.name)
+        end
+
+        within('#merchant-1') do 
+            expect(page).to have_link(merchant_2.name)
+        end
+
+        within('#merchant-2') do 
+            expect(page).to have_link(merchant_3.name)
+        end
+
+        within('#merchant-3') do 
+            expect(page).to have_link(merchant_4.name)
+            click_link(merchant_4.name)
+        end
+
+        expect(current_path).to eq("/admin/merchants/#{merchant_4.id}")
+        expect(page).to have_content(merchant_4.name)
+        expect(page).to_not have_content(merchant_1.name)
+        expect(page).to_not have_content(merchant_2.name)
+        expect(page).to_not have_content(merchant_3.name)
+    end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -205,3 +205,4 @@ RSpec.describe Merchant, type: :model do
     end
   end
 end
+end 


### PR DESCRIPTION
Admin Merchant Show

As an admin,
When I click on the name of a merchant from the admin merchants index page,
Then I am taken to that merchant's admin show page (/admin/merchants/merchant_id)
And I see the name of that merchant