### PR TITLE
US26 admin merchant update

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -2,4 +2,8 @@ class Admin::MerchantsController < ApplicationController
     def index 
         @merchants = Merchant.all 
     end
+
+    def show
+        @merchant = Merchant.find(params[:id])
+    end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -14,7 +14,7 @@ class Admin::MerchantsController < ApplicationController
     def update 
         merchant = Merchant.find(params[:id])
         merchant.update(merchant_params)
-        redirect_to admin_merchant_path(merchant)
+        redirect_to admin_merchant_path(merchant), notice: "Merchant information was successfully updated!"
     end
 
     private 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -6,4 +6,8 @@ class Admin::MerchantsController < ApplicationController
     def show
         @merchant = Merchant.find(params[:id])
     end
+
+    def edit 
+        @merchant = Merchant.find(params[:id])
+    end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -10,4 +10,15 @@ class Admin::MerchantsController < ApplicationController
     def edit 
         @merchant = Merchant.find(params[:id])
     end
+
+    def update 
+        merchant = Merchant.find(params[:id])
+        merchant.update(merchant_params)
+        redirect_to admin_merchant_path(merchant)
+    end
+
+    private 
+    def merchant_params 
+        params.permit(:name)
+    end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,0 +1,7 @@
+<h1>Edit Merchant Information</h1>
+
+<%= form_with url: admin_merchant_path(@merchant), method: :patch, local: true do |form| %>
+    <%= form.label :name, 'Updated Merchant Name' %>
+    <%= form.text_field :name, value: @merchant.name %>
+    <%= submit_tag("Update Information") %>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @merchants.each_with_index do |merchant, index| %>
     <div id = "merchant-<%=index %>">
-        <%= merchant.name %>
+        <%= link_to merchant.name, admin_merchant_path(merchant) %>
         <br>
     </div>
 <% end %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @merchant.name %></h1>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,7 @@
+<% flash.each do |type, msg| %>
+    <%= msg %>
+<% end %>
+
 <h1><%= @merchant.name %></h1>
 
 <%= link_to "Update Merchant Info", edit_admin_merchant_path(@merchant) %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,1 +1,3 @@
 <h1><%= @merchant.name %></h1>
+
+<%= link_to "Update Merchant Info", edit_admin_merchant_path(@merchant) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+
 module LittleEtsyShop
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :admin do 
-    resources :merchants, only: [:index, :show, :edit]
+    resources :merchants, only: [:index, :show, :edit, :update]
   end
 
   resources :merchants, only: [:index]  do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :admin do 
-    resources :merchants, only: [:index]
+    resources :merchants, only: [:index, :show]
   end
 
   resources :merchants, only: [:index]  do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :admin do 
-    resources :merchants, only: [:index, :show]
+    resources :merchants, only: [:index, :show, :edit]
   end
 
   resources :merchants, only: [:index]  do

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe 'Admin Merchants Edit page' do
     end
 
     # And I see a flash message stating that the information has been successfully updated.
+    it 'redirects to the Admin Merchant Show page with a flash message saying information has been successfully updated' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit admin_merchant_path(merchant_1)
+        click_link("Update Merchant Info")
+
+        new_name = Faker::Name.unique.name
+        fill_in "Name", with: new_name 
+        click_on("Update Information")
+
+        expect(page).to have_content("Merchant information was successfully updated!")
+    end
 end
 
 

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin Merchants Edit page' do 
+    # (Admin Merchant Update continued)
+    # And I see a form filled in with the existing merchant attribute information
+    # When I update the information in the form and I click ‘submit’
+    # Then I am redirected back to the merchant's admin show page where I see the updated information
+    it 'has a fillable form that redirects me to the Admin Merchants Show page with the updated information' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit admin_merchant_path(merchant_1)
+
+        expect(page).to have_content(merchant_1.name)
+
+        click_link("Update Merchant Info")
+
+        old_name = merchant_1.name 
+        new_name = Faker::Name.unique.name
+
+        expect(page).to have_field('Updated Merchant Name', with: old_name)
+
+        fill_in "Name", with: new_name 
+        click_on("Update Information")
+
+        expect(current_path).to eq "/admin/merchants/#{merchant_1.id}"
+        expect(page).to have_content(new_name)
+        expect(page).to_not have_content(old_name)
+    end
+
+    # And I see a flash message stating that the information has been successfully updated.
+end
+
+
+    

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Admin Merchants Index' do
         merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
         merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
 
-        visit '/admin/merchants' 
+        visit admin_merchants_path
         # save_and_open_page
 
         within('#merchant-0') do 
@@ -46,7 +46,7 @@ RSpec.describe 'Admin Merchants Index' do
         merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
         merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
 
-        visit '/admin/merchants' 
+        visit admin_merchants_path
 
         within('#merchant-0') do 
             expect(page).to have_link(merchant_1.name)

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -33,4 +33,42 @@ RSpec.describe 'Admin Merchants Index' do
             expect(page).to have_content(merchant_4.name)
         end
     end
+
+    # Admin Merchant Show
+    # As an admin,
+    # When I click on the name of a merchant from the admin merchants index page,
+    # Then I am taken to that merchant's admin show page (/admin/merchants/merchant_id)
+    # And I see the name of that merchant
+    it 'has links to the merchants admin show page' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit '/admin/merchants' 
+
+        within('#merchant-0') do 
+            expect(page).to have_link(merchant_1.name)
+        end
+
+        within('#merchant-1') do 
+            expect(page).to have_link(merchant_2.name)
+        end
+
+        within('#merchant-2') do 
+            expect(page).to have_link(merchant_3.name)
+        end
+
+        within('#merchant-3') do 
+            expect(page).to have_link(merchant_4.name)
+            click_link(merchant_4.name)
+        end
+
+        expect(current_path).to eq("/admin/merchants/#{merchant_4.id}")
+        expect(page).to have_content(merchant_4.name)
+        expect(page).to_not have_content(merchant_1.name)
+        expect(page).to_not have_content(merchant_2.name)
+        expect(page).to_not have_content(merchant_3.name)
+    end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper' 
-require 'pry'
 
 RSpec.describe 'Admin Merchant Show Page' do 
     # Admin Merchant Update
@@ -18,12 +17,4 @@ RSpec.describe 'Admin Merchant Show Page' do
 
         expect(current_path).to eq("/admin/merchants/#{merchant_1.id}/edit")
     end
-
-    # And I see a form filled in with the existing merchant attribute information
-    # When I update the information in the form and I click ‘submit’
-    # Then I am redirected back to the merchant's admin show page where I see the updated information
-
-
-    # And I see a flash message stating that the information has been successfully updated.
-
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper' 
+require 'pry'
+
+RSpec.describe 'Admin Merchant Show Page' do 
+    # Admin Merchant Update
+    # As an admin,
+    # When I visit a merchant's admin show page
+    # Then I see a link to update the merchant's information.
+    # When I click the link
+    # Then I am taken to a page to edit this merchant
+    it 'has a form to update the Merchant inforation' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit admin_merchant_path(merchant_1)
+
+        click_link("Update Merchant Info")
+
+        expect(current_path).to eq("/admin/merchants/#{merchant_1.id}/edit")
+    end
+
+    # And I see a form filled in with the existing merchant attribute information
+    # When I update the information in the form and I click ‘submit’
+    # Then I am redirected back to the merchant's admin show page where I see the updated information
+
+
+    # And I see a flash message stating that the information has been successfully updated.
+
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -205,3 +205,4 @@ RSpec.describe Merchant, type: :model do
     end
   end
 end
+end 


### PR DESCRIPTION
Admin Merchant Update

As an admin,
When I visit a merchant's admin show page
Then I see a link to update the merchant's information.
When I click the link
Then I am taken to a page to edit this merchant
And I see a form filled in with the existing merchant attribute information
When I update the information in the form and I click ‘submit’
Then I am redirected back to the merchant's admin show page where I see the updated information
And I see a flash message stating that the information has been successfully updated.