### PR TITLE
US29 admin merchant create

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -27,6 +27,16 @@ class Admin::MerchantsController < ApplicationController
         
     end
 
+    def create 
+        merchant = Merchant.new(merchant_params)
+        if merchant.save 
+            redirect_to admin_merchants_path
+        else 
+            flash[:alert] = "Merchant not created: Please enter a name."
+            render :new
+        end
+    end
+
     private 
     def merchant_params 
         params.permit(:name, :status)

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -21,6 +21,10 @@ class Admin::MerchantsController < ApplicationController
         end
     end
 
+    def new 
+        
+    end
+
     private 
     def merchant_params 
         params.permit(:name, :status)

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -16,6 +16,8 @@ class Admin::MerchantsController < ApplicationController
         merchant.update(merchant_params)
         if params[:status]
             redirect_to admin_merchants_path
+        elsif params[:name].blank? 
+            redirect_to edit_admin_merchant_path(params[:id]), alert: "Please enter a name."
         else 
             redirect_to admin_merchant_path(merchant), notice: "Merchant information was successfully updated!"
         end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,7 +1,7 @@
 class Merchant < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :status 
-  enum status: {"enabled": 0, "disabled": 1}
+  enum status: {"disabled": 0, "enabled": 1}
 
   has_many :items, dependent: :destroy
   has_many :invoice_items, through: :items 
@@ -43,11 +43,11 @@ class Merchant < ApplicationRecord
   end
 
   def self.enabled_merchants
-    Merchant.where("status = ?", 0).order(:created_at)
+    Merchant.where("status = ?", 1).order(:created_at)
   end
 
   def self.disabled_merchants
-    Merchant.where("status = ?", 1).order(:created_at)
+    Merchant.where("status = ?", 0).order(:created_at)
   end
 
   def top_5_revenue_generated

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,5 +1,9 @@
 <h1>Edit Merchant Information</h1>
 
+<% flash.each do |type, msg| %>
+    <%= msg %>
+<% end %>
+
 <%= form_with url: admin_merchant_path(@merchant), method: :patch, local: true do |form| %>
     <%= form.label :name, 'Updated Merchant Name' %>
     <%= form.text_field :name, value: @merchant.name %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,3 +1,6 @@
+
+<%= link_to 'New Merchant', new_admin_merchant_path %>
+
 <div id = 'enabled'>
 <h3>Enabled Merchants</h3>
     <% @merchants.enabled_merchants.each_with_index do |merchant, index| %>

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,0 +1,12 @@
+<h2>Create New Merchant</h2>
+
+<% flash.each do |type, msg| %>
+    <%= msg %>
+<% end %>
+
+<%= form_with url: admin_merchants_path, method: :post, local: true do |f| %>
+    <%= f.label :name, 'New Merchant Name' %>
+    <%= f.text_field :name %>
+
+    <%= f.submit 'Create New Merchant' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :admin do 
-    resources :merchants, only: [:index, :show, :edit, :update]
+    resources :merchants, only: [:index, :show, :edit, :update, :new]
   end
 
   resources :merchants, only: [:index]  do
@@ -13,5 +13,4 @@ Rails.application.routes.draw do
   end
 
   get "/merchants/:id/dashboard", to: "merchants#show"
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   root 'welcome#index'
 
   namespace :admin do 
-    resources :merchants, only: [:index, :show, :edit, :update, :new]
+    resources :merchants, only: [:index, :show, :edit, :update, :new, :create]
   end
 
   resources :merchants, only: [:index]  do

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Admin Merchants Edit page' do
         old_name = merchant_1.name 
         new_name = Faker::Name.unique.name
 
+        expect(current_path).to eq "/admin/merchants/#{merchant_1.id}/edit"
         expect(page).to have_field('Updated Merchant Name', with: old_name)
 
         fill_in "Name", with: new_name 
@@ -41,6 +42,21 @@ RSpec.describe 'Admin Merchants Edit page' do
         click_on("Update Information")
 
         expect(page).to have_content("Merchant information was successfully updated!")
+    end
+
+    it 'redirects to the edit form if no name is entered' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit admin_merchant_path(merchant_1)
+
+        click_link("Update Merchant Info")
+
+        fill_in "Name", with: ""
+        click_on("Update Information")
+
+        expect(current_path).to eq "/admin/merchants/#{merchant_1.id}/edit"
+        expect(page).to have_content('Please enter a name.')
     end
 end
 

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe 'Admin Merchants Index' do
     # Then I see the name of each merchant in the system
     it 'shows the name of each merchant in the system' do 
         Faker::UniqueGenerator.clear 
-        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
         visit admin_merchants_path
         # save_and_open_page
@@ -41,10 +41,10 @@ RSpec.describe 'Admin Merchants Index' do
     # And I see the name of that merchant
     it 'has links to the merchants admin show page' do 
         Faker::UniqueGenerator.clear 
-        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
         visit admin_merchants_path
 
@@ -84,38 +84,38 @@ RSpec.describe 'Admin Merchants Index' do
 
         visit admin_merchants_path
 
-        within("#enabled") do 
+        within("#disabled") do 
             expect(page).to have_content merchant_1.name 
             expect(page).to have_content merchant_2.name 
             expect(page).to have_content merchant_4.name 
             expect(page).to_not have_content merchant_3.name
         end
 
-        within("#disabled") do 
+        within("#enabled") do 
             expect(page).to have_content merchant_3.name 
             expect(page).to_not have_content merchant_1
             expect(page).to_not have_content merchant_2
             expect(page).to_not have_content merchant_4
         end
 
-        within("#e-merchant-0") do 
-            expect(page).to have_content merchant_1.name 
-            expect(page).to have_button "Disable"
-        end
-
-        within("#e-merchant-1") do 
-            expect(page).to have_content merchant_2.name 
-            expect(page).to have_button "Disable"
-        end
-
-        within("#e-merchant-2") do 
-            expect(page).to have_content merchant_4.name 
-            expect(page).to have_button "Disable"
-        end
-
         within("#d-merchant-0") do 
-            expect(page).to have_content merchant_3.name 
+            expect(page).to have_content merchant_1.name 
             expect(page).to have_button "Enable"
+        end
+
+        within("#d-merchant-1") do 
+            expect(page).to have_content merchant_2.name 
+            expect(page).to have_button "Enable"
+        end
+
+        within("#d-merchant-2") do 
+            expect(page).to have_content merchant_4.name 
+            expect(page).to have_button "Enable"
+        end
+
+        within("#e-merchant-0") do 
+            expect(page).to have_content merchant_3.name 
+            expect(page).to have_button "Disable"
         end
     end
 
@@ -124,10 +124,10 @@ RSpec.describe 'Admin Merchants Index' do
     # And I see that the merchant's status has changed
     it 'has buttons that changes the merchants status' do 
         Faker::UniqueGenerator.clear 
-        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_3 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
-        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
         visit admin_merchants_path
 
@@ -179,10 +179,10 @@ RSpec.describe 'Admin Merchants Index' do
     # And I see that each Merchant is listed in the appropriate section
     it 'groups merchants by status' do 
         Faker::UniqueGenerator.clear 
-        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
-        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_3 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
-        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
         visit admin_merchants_path
 
@@ -217,9 +217,4 @@ RSpec.describe 'Admin Merchants Index' do
 
         expect(current_path).to eq '/admin/merchants/new'
     end
-
-    # When I fill out the form I click ‘Submit’
-    # Then I am taken back to the admin merchants index page
-    # And I see the merchant I just created displayed
-    # And I see my merchant was created with a default status of disabled.
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -200,4 +200,26 @@ RSpec.describe 'Admin Merchants Index' do
             expect(page).to_not have_content merchant_4
         end
     end
+
+    # Admin Merchant Create
+    # As an admin,
+    # When I visit the admin merchants index
+    # I see a link to create a new merchant.
+    # When I click on the link,
+    # I am taken to a form that allows me to add merchant information.
+    it 'has a link to create a new merchant that directs to merchant#new' do 
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
+
+        visit admin_merchants_path
+        click_link 'New Merchant' 
+
+        expect(current_path).to eq '/admin/merchants/new'
+    end
+
+    # When I fill out the form I click ‘Submit’
+    # Then I am taken back to the admin merchants index page
+    # And I see the merchant I just created displayed
+    # And I see my merchant was created with a default status of disabled.
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper' 
+
+RSpec.describe 'form for new Merchant' do 
+    # When I fill out the form I click ‘Submit’
+    # Then I am taken back to the admin merchants index page
+    # And I see the merchant I just created displayed
+    # And I see my merchant was created with a default status of disabled.
+    it 'can create a new Merchant' do
+        merchant_name = Faker::Name.unique.name
+        visit new_admin_merchant_path
+
+        fill_in('New Merchant Name', with: merchant_name)
+        click_on 'Create New Merchant' 
+
+        expect(current_path).to eq '/admin/merchants'
+
+        
+    end
+end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -6,14 +6,25 @@ RSpec.describe 'form for new Merchant' do
     # And I see the merchant I just created displayed
     # And I see my merchant was created with a default status of disabled.
     it 'can create a new Merchant' do
-        merchant_name = Faker::Name.unique.name
+        Faker::UniqueGenerator.clear 
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        
+        merchant_3_name = Faker::Name.unique.name
         visit new_admin_merchant_path
 
-        fill_in('New Merchant Name', with: merchant_name)
+        fill_in('New Merchant Name', with: merchant_3_name)
         click_on 'Create New Merchant' 
 
         expect(current_path).to eq '/admin/merchants'
-
         
+        within('#enabled') do 
+            expect(page).to have_content merchant_1.name
+            expect(page).to have_content merchant_2.name
+        end
+
+        within('#disabled') do 
+            expect(page).to have_content merchant_3_name
+        end
     end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'form for new Merchant' do
         visit new_admin_merchant_path
 
         fill_in('New Merchant Name', with: merchant_3_name)
-        click_on 'Create New Merchant' 
+        click_on 'Create New Merchant'
 
         expect(current_path).to eq '/admin/merchants'
         
@@ -26,5 +26,14 @@ RSpec.describe 'form for new Merchant' do
         within('#disabled') do 
             expect(page).to have_content merchant_3_name
         end
+    end
+
+    it 'goes back to form with error message if no name is submitted' do
+        visit new_admin_merchant_path
+
+        fill_in('New Merchant Name', with: "")
+        click_on 'Create New Merchant'
+        
+        expect(page).to have_content 'Merchant not created: Please enter a name.'
     end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Merchant, type: :model do
     describe '#enabled_merchants' do 
       it 'returns only the enabled merchants' do 
         Faker::UniqueGenerator.clear 
-        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_3 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
-        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
         expect(Merchant.enabled_merchants).to eq([merchant_1, merchant_2, merchant_4])
       end
@@ -34,10 +34,10 @@ RSpec.describe Merchant, type: :model do
     describe '#disabled_merchants' do 
       it 'returns only the disabled merchants' do 
         Faker::UniqueGenerator.clear 
-        merchant_1 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_2 = Merchant.create!(name: Faker::Name.unique.name)
-        merchant_3 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
-        merchant_4 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_1 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_2 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
+        merchant_3 = Merchant.create!(name: Faker::Name.unique.name)
+        merchant_4 = Merchant.create!(name: Faker::Name.unique.name, status: 1)
 
         expect(Merchant.disabled_merchants).to eq([merchant_3])
       end
@@ -356,4 +356,3 @@ RSpec.describe Merchant, type: :model do
     end
   end
 end
-end 


### PR DESCRIPTION
Admin Merchant Create

As an admin,
When I visit the admin merchants index
I see a link to create a new merchant.
When I click on the link,
I am taken to a form that allows me to add merchant information.
When I fill out the form I click ‘Submit’
Then I am taken back to the admin merchants index page
And I see the merchant I just created displayed
And I see my merchant was created with a default status of disabled.